### PR TITLE
For newer docker CLI do not run publish steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,14 +10,18 @@ pipeline:
     pattern: coverage/lcov.info
     server: https://aircover.co
     when:
+      event: push
       branch: master
+      local: false
   publish:
     image: plugins/docker
     repo: athieriot/drone-artifactory
     tag: latest
     when:
+      event: push
       branch: master
-      
+      local: false
+
 plugin:
   name: Artifactory
   desc: Publish files and artifacts to Artifactory


### PR DESCRIPTION
Due to work being done to accomplish https://github.com/drone/drone/issues/1906 plugin steps are ran from newer CLI unless explicitly defined not to.

Adding not to run publish steps when pipeline is executed from CLI.