### PR TITLE
Support Drone 0.5

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,3 @@
-const Drone = require('drone-node');
-const plugin = new Drone.Plugin();
-
 const ArtifactoryAPI = require('artifactory-api');
 const pomParser = require("pom-parser");
 const glob = require("glob");
@@ -134,6 +131,9 @@ if(require.main === module) {
 
   // Drone is 0.4
   } else {
+    const Drone = require('drone-node');
+    const plugin = new Drone.Plugin();
+
     plugin.parse()
     .then(check_params)
     .then(do_upload)


### PR DESCRIPTION
The previous support for Drone 0.5 did not actually work. This
was because the `drone-node`  plugin was being instatniated regardless
of node version which fails since it tries to parse the input JSON.